### PR TITLE
Fix: Update base URL for Anime-Sama source

### DIFF
--- a/dart/anime/src/fr/animesama/source.dart
+++ b/dart/anime/src/fr/animesama/source.dart
@@ -6,7 +6,7 @@ const animesamaCodeUrl =
     "https://raw.githubusercontent.com/m2k3a/mangayomi-extensions/$branchName/dart/anime/src/fr/animesama/animesama.dart";
 Source _animesama = Source(
   name: "Anime-Sama",
-  baseUrl: "https://anime-sama.fr",
+  baseUrl: "https://anime-sama.tv",
   lang: "fr",
   typeSource: "single",
   iconUrl:


### PR DESCRIPTION
Changed the baseUrl to match the new one after DNS blocking in France. 

In the future, it might become necessary to dynamically pull the baseUrl from anime-sama.pw, but I have no idea if this will work within the applications. 