### PR TITLE
Teamx extension fix

### DIFF
--- a/javascript/manga/src/ar/teamx.js
+++ b/javascript/manga/src/ar/teamx.js
@@ -125,7 +125,6 @@ class DefaultExtension extends MProvider {
     const chpNum = element.selectFirst("div.chapter-info > div.chapter-number")?.text.trim();
     const chpTitle = element.selectFirst("div.chapter-info > div.chapter-title")?.text.trim();
     const date = element? element.attr("data-date") + "000" : "0";
-    console.log(date);
     return {
       name: chpNum || `الفصل ${chapterNumber}`,
       description: chpTitle || "",


### PR DESCRIPTION
* added headers functionality
* cloudflare tries


## Fixes
- Fixed search function

- Fixed details
  >  now it will give correct listing of chapters

  this way will only parse last 100 chapters **date** and **name** from page while the chapters left from `N-100` to `first chapter` are generated automatically with default values

- pageList now returns urls with heaeders